### PR TITLE
ASM-4370 NetApp puppet discovery is failing in ASM 8.1.1 build 4913

### DIFF
--- a/lib/puppet/util/network_device/netapp/device.rb
+++ b/lib/puppet/util/network_device/netapp/device.rb
@@ -23,7 +23,8 @@ class Puppet::Util::NetworkDevice::Netapp::Device
     raise ArgumentError, "no password specified" unless @url.password
 
     @transport ||= NaServer.new(@url.host, 1, 13)
-    password = URI.decode(asm_decrypt(@url.password))
+    #password = URI.decode(asm_decrypt(@url.password))
+    password = URI.decode(@url.password)
     @transport.set_admin_user(URI.decode(@url.user), password)
     @transport.set_transport_type(@url.scheme.upcase)
     @transport.set_port(@url.port)


### PR DESCRIPTION
Removed asm_decrypt invocation from the transport that was leading to the authentication error