### PR TITLE
ASM-4395 check user/pass after overriding from credential

### DIFF
--- a/lib/puppet/util/network_device/netapp/device.rb
+++ b/lib/puppet/util/network_device/netapp/device.rb
@@ -17,13 +17,21 @@ class Puppet::Util::NetworkDevice::Netapp::Device
 
     Puppet.debug("Puppet::Device::Netapp: connecting to Netapp device #{redacted_url}")
 
+    user = URI.decode(@url.user) if @url.user
+    password = URI.decode(@url.password) if @url.password
+    if id = @query.fetch('credential_id', []).first
+      require 'asm/cipher'
+      cred = ASM::Cipher.decrypt_credential(id)
+      user = cred.username
+      password = cred.password
+    end
+
     raise ArgumentError, "Invalid scheme #{@url.scheme}. Must be https" unless @url.scheme == 'https'
-    raise ArgumentError, "no user specified" unless @url.user
-    raise ArgumentError, "no password specified" unless @url.password
+    raise ArgumentError, "no user specified" unless user
+    raise ArgumentError, "no password specified" unless password
 
     @transport ||= NaServer.new(@url.host, 1, 13)
-    password = URI.decode(@url.password)
-    @transport.set_admin_user(URI.decode(@url.user), password)
+    @transport.set_admin_user(user, password)
     @transport.set_transport_type(@url.scheme.upcase)
     @transport.set_port(@url.port)
     if match = %r{/([^/]+)}.match(@url.path)
@@ -32,8 +40,6 @@ class Puppet::Util::NetworkDevice::Netapp::Device
       Puppet.debug("Puppet::Device::Netapp: vfiler context has been set to #{@vfiler}")
     end
     
-    override_using_credential_id
-
     result = @transport.invoke("system-get-version")
     if(result.results_errno != 0)
       r = result.results_reason
@@ -44,14 +50,6 @@ class Puppet::Util::NetworkDevice::Netapp::Device
     end
   end
 		
-  def override_using_credential_id
-    if id = @query.fetch('credential_id', []).first
-      require 'asm/cipher'
-      cred = ASM::Cipher.decrypt_credential(id)
-      @transport.set_admin_user(cred.username, cred.password)
-    end
-  end
-
   def facts
     @facts ||= Puppet::Util::NetworkDevice::Netapp::Facts.new(@transport)
     facts = @facts.retrieve


### PR DESCRIPTION
Device configuration files no longer include a username and password
by default; that should be set by the credential_i