### PR TITLE
ASM-4404 Create_nfs_export

### DIFF
--- a/lib/puppet/provider/netapp_export/netapp_export.rb
+++ b/lib/puppet/provider/netapp_export/netapp_export.rb
@@ -202,9 +202,7 @@ Puppet::Type.type(:netapp_export).provide(:netapp_export, :parent => Puppet::Pro
         result = emodify('persistent', @resource[:persistent].to_s, 'rule', rule_list)
       rescue Exception => exc
         if exc.message.downcase.include?("no such file")
-          Puppet.debug "Export operation failed. Need to retry after 10 seconds"
-          sleep(10)
-          result = emodify('persistent', @resource[:persistent].to_s, 'rule', rule_list)
+          Puppet.debug "Export operation failed with error 'no such file'. This can be ignored"
         end
       end
       


### PR DESCRIPTION
NFS export operation fails intermittently when the export configuration is modified. This happens during the server scale-up operation from ASM
The IP Address of the newly added server is updated in the export file but due to sync issue, this error is reported by ONTAP API.

No resolution for this is suggested in the NetApp KB Articles, but based on the observation so far, removing the extra invocation as this is not solving the problem but instead leading to the failure of the ASM deployment where scale-up operation is performed